### PR TITLE
🎨 Update styles.css to adapt color to the selected theme

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,1 +1,9 @@
-/* Nothing to do here really, default abcjs styles look good */
+/* Default abcjs styles look good. Just adapting it to the current theme.  */
+
+.abcjs-container svg path {
+  fill: var(--text-normal);
+}
+
+.abcjs-container svg text {
+  fill: var(--text-normal);
+}


### PR DESCRIPTION
Hi, 

## Issue 
abc.js default style is great, but it doesn't adapt to the user's selected theme in Obsidian. 
This is an issue especially in dark-mode, as black on black isn't really convenient to read though. 

![Screenshot 2021-01-01 at 15 41 51](https://user-images.githubusercontent.com/29660796/103440672-e72ff180-4c47-11eb-9e19-c607d5f5361d.png)

## Fix 
Set SVG fills to `--text-normal` in `styles.css` to brings back readability and consistency. 

![Screenshot 2021-01-01 at 15 40 56](https://user-images.githubusercontent.com/29660796/103440693-09c20a80-4c48-11eb-8e47-904b66955689.png)

Hope this will help!