### PR TITLE
Update style.css to include braces

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -7,3 +7,7 @@
 .abcjs-container svg text {
   fill: var(--text-normal);
 }
+
+.abcjs-brace {
+  stroke: var(--text-normal);
+}


### PR DESCRIPTION
When using more than one staff (with `%%staves {1 2}` for example) the brace across them should be drawn using the normal text colour like other elements. Previously it would be drawn in black even in Dark mode (because it uses `stroke:` I guess).